### PR TITLE
Reorganize a bit and describe our trust models

### DIFF
--- a/draft-wang-ppm-differential-privacy.md
+++ b/draft-wang-ppm-differential-privacy.md
@@ -328,8 +328,8 @@ underlying primitives (VDAF {{!VDAF}}, HPKE {{!RFC9180}}, and the transport
 security protocol).
 
 To account for such attackers, our goal for DAP is "computational-DP" as
-described by {{MPRV09}}, which formalizes the amount of information active
-attacker gleans about the measurement over the course of its attack on the
+described by {{MPRV09}}, which formalizes the amount of information an active
+attacker can glean about the measurements over the course of its attack on the
 protocol. We consider an attacker that controls the network and statically
 corrupts a subset of the parties.
 

--- a/draft-wang-ppm-differential-privacy.md
+++ b/draft-wang-ppm-differential-privacy.md
@@ -378,7 +378,8 @@ Clients' measurements have "local-DP". This property is defined the same way as
 pure- or approximate-DP, except that the bound we aim to achieve is much looser
 than usual. For example, if the parameters of a DP policy are tuned for OAMC
 security, but both Aggregators are corrupted by the attacker, then the noise
-added by the Client may not be sufficient to protect the measurement.
+added by the Client may not be sufficient to protect the measurement. Howver
+this is the best possible case in such a stringent threat model.
 
 # DP Mechanisms {#mechanisms}
 


### PR DESCRIPTION
Closes #15 by doing nothing. (COA security assumes the Collector doesn't share the aggregate result with the honest Aggregator.)