### PR TITLE
Set up reference implementation folder

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "poc/draft-irtf-cfrg-vdaf"]
+	path = poc/draft-irtf-cfrg-vdaf
+	url = https://github.com/cfrg/draft-irtf-cfrg-vdaf.git

--- a/poc/Makefile
+++ b/poc/Makefile
@@ -1,0 +1,6 @@
+test:
+	sage -python mechanism/binary_randomized_response.py
+	sage -python mechanism/discrete_gaussian.py
+	sage -python mechanism/discrete_laplace.py
+	sage -python policy/histogram_with_aggregator_dp.py
+	sage -python policy/multi_hot_histogram_with_client_dp.py

--- a/poc/mechanism/binary_randomized_response.py
+++ b/poc/mechanism/binary_randomized_response.py
@@ -1,0 +1,42 @@
+"""
+Binary randomized response mechanism from Appendix C.1 in
+https://arxiv.org/pdf/2211.10082.pdf.
+"""
+
+import math
+
+from mechanism import DpMechanism
+
+
+class BinaryRandomizedResponse(DpMechanism):
+    DataType = list[int]
+    # Debiasing produces an array of floats.
+    DebiasedDataType = list[float]
+
+    def __init__(self, eps0: float):
+        self.eps0 = eps0
+        self.p = 1.0 / (math.exp(eps0) + 1.0)
+
+    def add_noise(self, data: DataType) -> DataType:
+        # TODO: Implement this (#10).
+        raise NotImplementedError()
+
+    def sample_noise(self, dimension: int) -> DataType:
+        # TODO: Implement this (#10).
+        raise NotImplementedError()
+
+    def debias(self,
+               data: DataType,
+               meas_count: int) -> DebiasedDataType:
+        # TODO: Implement this (#10).
+        raise NotImplementedError()
+
+
+def test():
+    rr = BinaryRandomizedResponse(8.0)
+    # Expect this to fail before it is implemented.
+    rr.sample_noise(100)
+
+
+if __name__ == '__main__':
+    test()

--- a/poc/mechanism/discrete_gaussian.py
+++ b/poc/mechanism/discrete_gaussian.py
@@ -1,0 +1,34 @@
+"""
+Discrete Gaussian sampler from Algorithm 3 of
+https://arxiv.org/pdf/2004.00010.pdf.
+"""
+
+from mechanism import DpMechanism
+
+
+class DiscreteGaussianWithZeroMean(DpMechanism):
+    DataType = list[int]
+    DebiasedDataType = DataType
+
+    def __init__(self, sigma: float):
+        # TODO: Consider using fixed precision or rationals to represent this
+        # parameter (#23).
+        self.sigma = sigma
+
+    def add_noise(self, data: DataType) -> DataType:
+        # TODO: Implement this (#10).
+        raise NotImplementedError()
+
+    def sample_noise(self, dimension: int) -> DataType:
+        # TODO: Implement this (#10).
+        raise NotImplementedError()
+
+
+def test():
+    dgauss = DiscreteGaussianWithZeroMean(2.0)
+    # Expect this to fail before it is implemented.
+    dgauss.sample_noise(100)
+
+
+if __name__ == '__main__':
+    test()

--- a/poc/mechanism/discrete_laplace.py
+++ b/poc/mechanism/discrete_laplace.py
@@ -1,0 +1,34 @@
+"""
+Discrete Laplace sampler from Algorithm 2 of
+https://arxiv.org/pdf/2004.00010.pdf.
+"""
+
+from mechanism import DpMechanism
+
+
+class DiscreteLaplaceWithZeroMean(DpMechanism):
+    DataType = list[int]
+    DebiasedDataType = DataType
+
+    def __init__(self, t: int, s: int):
+        # t/s defines the scale of Laplace.
+        self.t = t
+        self.s = s
+
+    def add_noise(self, data: DataType) -> DataType:
+        # TODO: Implement this (#10).
+        raise NotImplementedError()
+
+    def sample_noise(self, dimension: int) -> DataType:
+        # TODO: Implement this (#10).
+        raise NotImplementedError()
+
+
+def test():
+    laplace = DiscreteLaplaceWithZeroMean(3, 1)
+    # Expect this to fail before it is implemented.
+    laplace.sample_noise(100)
+
+
+if __name__ == '__main__':
+    test()

--- a/poc/mechanism/mechanism.py
+++ b/poc/mechanism/mechanism.py
@@ -1,0 +1,35 @@
+"""
+Interface for DP mechanisms.
+
+A DP mechanism is responsible for sampling noise and adding it to the data with
+the type applicable to the DP mechanism.
+"""
+
+class DpMechanism:
+    # The data type applicable to this `DpMechanism`. The type is the same for
+    # the noised data and the un-noised data.
+    DataType = None
+    # Debiased data type after removing bias added by the noise. For most of the
+    # mechanisms, `DebiasedDataType == DataType`.
+    DebiasedDataType = None
+
+    def add_noise(self, data: DataType) -> DataType:
+        """Add noise to a piece of input data. """
+        raise NotImplementedError()
+
+    def sample_noise(self, dimension: int) -> DataType:
+        """
+        Sample noise with the initialized `DpMechanism`. `dimension` is used to
+        determine the length of the output if `DataType` is a list.
+        """
+        raise NotImplementedError()
+
+    def debias(self,
+               data: DataType,
+               meas_count: int) -> DebiasedDataType:
+        """
+        Debias the data due to the added noise, based on the number of
+        measurements `meas_count`. This doesn't apply to all DP mechanisms.
+        Some Client-DP mechanisms need this functionality.
+        """
+        return data

--- a/poc/policy/histogram_with_aggregator_dp.py
+++ b/poc/policy/histogram_with_aggregator_dp.py
@@ -1,0 +1,75 @@
+"""
+A policy that uses only Aggregator-DP to achieve central `(EPSILON, DELTA)`-DP
+in the OAOC trust model.
+
+Each Aggregator independently adds discrete Gaussian noise to its aggregate
+share, so that as long as at least one Aggregator is honest, the final
+aggregate result is `(EPSILON, DELTA)`-differentially private. If both
+Aggregators are honest, then we will lose some utility.
+"""
+
+# Access files that live in different directories, since currently the source
+# files are not module-based.
+import os
+import sys
+# `dir_name` points to the `poc` folder in DP draft.
+dir_name = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+# Access files in `mechanism` folder.
+# TODO(junyechen1996): Remove after #24.
+sys.path.append(os.path.join(dir_name, "mechanism"))
+# Access files in VDAF `poc` folder.
+sys.path.append(os.path.join(dir_name, "draft-irtf-cfrg-vdaf", "poc"))
+from flp_generic import Histogram
+
+from discrete_gaussian import DiscreteGaussianWithZeroMean
+from policy import DpPolicy
+
+
+class HistogramWithAggregatorDp(DpPolicy):
+    Field = Histogram.Field
+    # A measurement is an unsigned integer, indicating an index
+    # less than `Histogram.length`.
+    Measurement = Histogram.Measurement
+    AggShare = list[Field]
+    AggResult = Histogram.AggResult
+    # The final aggregate result should be a vector of *signed* integers,
+    # because discrete Gaussian could produce negative noise which may have
+    # a larger absolute value than the count before noise.
+    DebiasedAggResult = list[int]
+
+    def __init__(self, epsilon: float, delta: float):
+        # TODO(junyechen1996): Compute discrete Gaussian parameter to
+        # achieve (eps, delta)-DP based on
+        # https://github.com/BorjaBalle/analytic-gaussian-mechanism.
+        self.dgauss_mechanism = DiscreteGaussianWithZeroMean(100.0)
+
+    def add_noise_to_agg_share(self,
+                               agg_share: AggShare,
+                               ) -> AggShare:
+        """
+        Sample discrete Gaussian noise, and merge it with
+        aggregate share.
+        """
+        raise NotImplementedError()
+
+    def debias_agg_result(self,
+                          agg_result: AggResult,
+                          meas_count: int,
+                          ) -> DebiasedAggResult:
+        # TODO(junyechen1996): Interpret large unsigned integers as negative
+        # values or 0 properly.
+        raise NotImplementedError()
+
+
+def test():
+    histogram_with_dp = HistogramWithAggregatorDp(0.03, 1e-9)
+    # This should return measurement as-is.
+    histogram_with_dp.add_noise_to_measurement(0)
+    # Expect this to fail before it is implemented.
+    histogram_with_dp.add_noise_to_agg_share(
+        [HistogramWithAggregatorDp.Field(0)]
+    )
+
+
+if __name__ == '__main__':
+    test()

--- a/poc/policy/multi_hot_histogram_with_client_dp.py
+++ b/poc/policy/multi_hot_histogram_with_client_dp.py
@@ -1,0 +1,60 @@
+"""
+A policy that uses only Client-DP to achieve central `(EPSILON, DELTA)`-DP in
+the OAMC trust model.
+
+Each Client adds binary randomized response noise with pure `EPSILON_0`-DP. With
+the target `batch_size` number of honest Clients, the final aggregate result is
+`(EPSILON, DELTA)`-DP. If the number of Clients does not meet `batch_size`, the
+batch will be dropped.
+"""
+
+# Access files that live in different directories, since currently the source
+# files are not module-based.
+import os
+import sys
+# `dir_name` points to the `poc` folder in DP draft.
+dir_name = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+# Access files in `mechanism` folder.
+# TODO(junyechen1996): Remove after #24.
+sys.path.append(os.path.join(dir_name, "mechanism"))
+# Access files in VDAF `poc` folder.
+sys.path.append(os.path.join(dir_name, "draft-irtf-cfrg-vdaf", "poc"))
+from flp_generic import MultiHotHistogram
+
+from binary_randomized_response import BinaryRandomizedResponse
+from policy import DpPolicy
+
+
+class MultiHotHistogramWithClientDp(DpPolicy):
+    Field = MultiHotHistogram.Field
+    Measurement = MultiHotHistogram.Measurement
+    AggShare = list[Field]
+    AggResult = MultiHotHistogram.AggResult
+    DebiasedAggResult = BinaryRandomizedResponse.DebiasedDataType
+
+    def __init__(self, eps0: float):
+        # TODO(junyechen1996): Justify how eps0 + min_batch_size can achieve
+        # (eps, delta)-DP.
+        self.rr = BinaryRandomizedResponse(eps0)
+
+    def add_noise_to_measurement(self,
+                                 meas: Measurement,
+                                 ) -> Measurement:
+        return self.rr.add_noise(meas)
+
+    def debias_agg_result(self,
+                          agg_result: AggResult,
+                          meas_count: int,
+                          ) -> DebiasedAggResult:
+        # TODO(junyechen1996): Implement de-biasing.
+        raise NotImplementedError()
+
+
+def test():
+    multi_hot_histogram_with_dp = MultiHotHistogramWithClientDp(8.0)
+    # Expect this to fail before it is implemented.
+    multi_hot_histogram_with_dp.add_noise_to_measurement([0])
+
+
+if __name__ == '__main__':
+    test()

--- a/poc/policy/policy.py
+++ b/poc/policy/policy.py
@@ -1,0 +1,48 @@
+"""
+Interface for DP policies.
+
+A DP policy is executed with the corresponding VDAF, and relies on some or
+all parties of an aggregation protocol to add the right amount of noise to
+ensure the final aggregate result is differentially private. The actual
+parties that participate in adding noise depends on the threat model that the
+DP policy is designed for.
+"""
+
+class DpPolicy:
+    # Client measurement type.
+    Measurement = None
+    # Aggregate share type, owned by an Aggregator.
+    AggShare = None
+    # Aggregate result type, unsharded result from all Aggregators.
+    AggResult = None
+    # Debiased aggregate result type.
+    DebiasedAggResult = None
+
+    def add_noise_to_measurement(self,
+                                 meas: Measurement,
+                                 ) -> Measurement:
+        """
+        Add noise to measurement, if required by the Client-DP mechanism.
+        The default implementation is to do nothing.
+        """
+        return meas
+
+    def add_noise_to_agg_share(self,
+                               agg_share: AggShare,
+                               ) -> AggShare:
+        """
+        Add noise to aggregate share, if required by the Aggregator-DP mechanism.
+        The default implementation is to do nothing.
+        """
+        return agg_share
+
+    def debias_agg_result(self,
+                          agg_result: AggResult,
+                          meas_count: int,
+                          ) -> DebiasedAggResult:
+        """
+        Debias aggregate result, if any of the Client- or Aggregator-DP
+        mechanism requires this operation, based on the number of measurements
+        `meas_count`. The default implementation is to do nothing.
+        """
+        return agg_result


### PR DESCRIPTION
Set up reference implementation folder structure with the DP mechanisms, DP policies, and the submoduled VDAF reference implementation.